### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15.0
 
-RUN apk add --update openssh borgbackup tzdata && \
+RUN apk add --update openssh borgbackup tzdata py3-pip && \
     rm  -rf /tmp/* /var/cache/apk/*
 
 EXPOSE 22


### PR DESCRIPTION
I needed to add py3-pip to get this to work. Error I got after ssh'ing into the server:

Traceback (most recent call last):
  File "/usr/bin/borg", line 33, in <module>
    sys.exit(load_entry_point('borgbackup==1.1.17', 'console_scripts', 'borg')())
  File "/usr/bin/borg", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib/python3.9/importlib/metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 972, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/lib/python3.9/site-packages/borg/__init__.py", line 1, in <module>
    from packaging.version import parse as parse_version
ModuleNotFoundError: No module named 'packaging'